### PR TITLE
Fix "Unsupported client" error by updating auth and headers

### DIFF
--- a/granola_client/http_client.py
+++ b/granola_client/http_client.py
@@ -97,9 +97,17 @@ class HttpClient:
         await self._ensure_token()
         url = f"{self.base_url_str}{path}"
 
+        # Build User-Agent in standard browser format (matches official Granola Electron app)
+        os_name = "Macintosh; Intel Mac OS X" if self.client_platform == "darwin" else self.client_platform
+        os_version_ua = self.os_version.replace(".", "_") if self.client_platform == "darwin" else self.os_version
+        user_agent = (
+            f"Mozilla/5.0 ({os_name} {os_version_ua}) AppleWebKit/537.36 (KHTML, like Gecko) "
+            f"Granola/{self.app_version} Chrome/{self.chrome_version} Electron/{self.electron_version} Safari/537.36"
+        )
+
         headers: Dict[str, str] = {
             "X-App-Version": self.app_version,
-            "User-Agent": f"Granola/{self.app_version} Electron/{self.electron_version} Chrome/{self.chrome_version} Node/{self.node_version} ({self.client_platform} {self.os_version}; {self.os_build})".strip(),
+            "User-Agent": user_agent,
             "X-Client-Type": self.client_type,
             "X-Client-Platform": self.client_platform,
             "X-Client-Architecture": self.client_architecture,

--- a/granola_client/types.py
+++ b/granola_client/types.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, Field, HttpUrl, ConfigDict, computed_field
 class HttpOpts(BaseModel):
     timeout: Optional[int] = 10000  # milliseconds
     retries: Optional[int] = 3
-    app_version: Optional[str] = Field(default="6.4.0", alias="appVersion")
+    app_version: Optional[str] = Field(default="6.531.0", alias="appVersion")
     client_type: Optional[str] = Field(
         default="electron", alias="clientType"
     )  # Consider "python-httpx"
@@ -17,11 +17,11 @@ class HttpOpts(BaseModel):
     client_architecture: Optional[str] = Field(
         default=None, alias="clientArchitecture"
     )  # Will be auto-detected
-    electron_version: Optional[str] = Field(default="33.4.5", alias="electronVersion")
+    electron_version: Optional[str] = Field(default="39.2.7", alias="electronVersion")
     chrome_version: Optional[str] = Field(
-        default="130.0.6723.191", alias="chromeVersion"
+        default="142.0.7444.235", alias="chromeVersion"
     )
-    node_version: Optional[str] = Field(default="20.18.3", alias="nodeVersion")
+    node_version: Optional[str] = Field(default="22.21.1", alias="nodeVersion")
     os_version: Optional[str] = Field(
         default=None, alias="osVersion"
     )  # Will be auto-detected


### PR DESCRIPTION
- Use WorkOS tokens instead of Cognito (Granola migrated auth)
- Update version headers to match current Granola app (6.531.0)
- Fix User-Agent format to standard browser format