### PR TITLE
Add PyPI publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,10 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -62,3 +64,17 @@ jobs:
           tag_name: v${{ inputs.version }}
           name: v${{ inputs.version }}
           generate_release_notes: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Build package
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## Summary
- Adds build and PyPI publish steps directly to the release workflow
- Fixes issue where `publish.yml` wasn't triggering after automated releases (because GitHub doesn't trigger workflows from `github-actions[bot]` actions)
- Keeps `publish.yml` as a fallback for manual releases/tags

## Test plan
- [ ] Merge and run the Release workflow with a new version
- [ ] Verify package appears on PyPI